### PR TITLE
Correct Configuration Names in Example files - Fixes #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   to root folder of repository and remove test harness - Fixes [Issue #11](https://github.com/PlagueHO/FileContentDsc/issues/11).
 - Converted Examples to support format for publishing to PowerShell
   Gallery.
-- Refactor Test-TargetResource to return $false in all DSC resource -Fixes [Issue #12](https://github.com/PlagueHO/FileContentDsc/issues/13)
+- Refactor Test-TargetResource to return $false in all DSC resource - Fixes
+  [Issue #12](https://github.com/PlagueHO/FileContentDsc/issues/13).
+- Correct configuration names in Examples - fixes [Issue #15](https://github.com/PowerShell/FileContentDsc/issues/15).
 
 ## 1.0.0.0
 

--- a/Examples/Resources/IniSettingsFile/1-IniSettingsFile_SetPlainTextEntry_Config.ps1
+++ b/Examples/Resources/IniSettingsFile/1-IniSettingsFile_SetPlainTextEntry_Config.ps1
@@ -22,7 +22,7 @@
     Set the `Level` entry in the [Logging] section to `Information`
     in the file `c:\myapp\myapp.ini`.
 #>
-Configuration Example
+Configuration IniSettingsFile_SetPlainTextEntry_Config
 {
     Import-DSCResource -ModuleName FileContentDsc
 

--- a/Examples/Resources/IniSettingsFile/2-IniSettingsFile_SetSecretTextEntry_Config.ps1
+++ b/Examples/Resources/IniSettingsFile/2-IniSettingsFile_SetSecretTextEntry_Config.ps1
@@ -22,7 +22,7 @@
     Set the `ConnectionString` entry in the [Database] section to the password
     provided in the $Secret credential object in the file `c:\myapp\myapp.ini`.
 #>
-Configuration Example
+Configuration IniSettingsFile_SetSecretTextEntry_Config
 {
     param
     (

--- a/Examples/Resources/KeyValuePairFile/1-KeyValuePairFile_RemovePlainTextPair_Config.ps1
+++ b/Examples/Resources/KeyValuePairFile/1-KeyValuePairFile_RemovePlainTextPair_Config.ps1
@@ -21,7 +21,7 @@
     .DESCRIPTION
     Remove all `Core.Logging` keys in the file `c:\myapp\myapp.conf`.
 #>
-Configuration Example
+Configuration KeyValuePairFile_RemovePlainTextPair_Config
 {
     Import-DSCResource -ModuleName FileContentDsc
 

--- a/Examples/Resources/KeyValuePairFile/2-KeyValuePairFile_SetPlainTextPair_Config.ps1
+++ b/Examples/Resources/KeyValuePairFile/2-KeyValuePairFile_SetPlainTextPair_Config.ps1
@@ -22,7 +22,7 @@
     Set all `Core.Logging` keys to `Information` or add it
     if it is missing in the file `c:\myapp\myapp.conf`.
 #>
-Configuration Example
+Configuration KeyValuePairFile_SetPlainTextPair_Config
 {
     Import-DSCResource -ModuleName FileContentDsc
 

--- a/Examples/Resources/KeyValuePairFile/3-KeyValuePairFile_SetSecretTextPair_Config.ps1
+++ b/Examples/Resources/KeyValuePairFile/3-KeyValuePairFile_SetSecretTextPair_Config.ps1
@@ -22,7 +22,7 @@
     Set all `Core.Password` keys to the password provided in the $Secret
     credential object or add it if it is missing in the file `c:\myapp\myapp.conf`.
 #>
-Configuration Example
+Configuration KeyValuePairFile_SetSecretTextPair_Config
 {
     param
     (

--- a/Examples/Resources/ReplaceText/1-ReplaceText_ReplacePlainSecretText_Config.ps1
+++ b/Examples/Resources/ReplaceText/1-ReplaceText_ReplacePlainSecretText_Config.ps1
@@ -23,7 +23,7 @@
     the password set in the parameter $Secret PSCredential object
     in the file `c:\inetpub\wwwroot\default.htm`.
 #>
-Configuration Example
+Configuration ReplaceText_ReplacePlainSecretText_Config
 {
     param
     (

--- a/Examples/Resources/ReplaceText/2-ReplaceText_ReplacePlainText_Config.ps1
+++ b/Examples/Resources/ReplaceText/2-ReplaceText_ReplacePlainText_Config.ps1
@@ -22,7 +22,7 @@
     Set all occrurances of the string `%appname%` to be Awesome App`
     in the file `c:\inetpub\wwwroot\default.htm`.
 #>
-Configuration Example
+Configuration ReplaceText_ReplacePlainText_Config
 {
     Import-DSCResource -ModuleName FileContentDsc
 

--- a/Examples/Resources/ReplaceText/3-ReplaceText_ReplaceRegexText_Config.ps1
+++ b/Examples/Resources/ReplaceText/3-ReplaceText_ReplaceRegexText_Config.ps1
@@ -23,7 +23,7 @@
     `<img src=['``"][a-zA-Z0-9.]*['``"]>` with the text `<img src="imgs/placeholder.jpg">`
     in the file `c:\inetpub\wwwroot\default.htm`
 #>
-Configuration Example
+Configuration ReplaceText_ReplaceRegexText_Config
 {
     Import-DSCResource -ModuleName FileContentDsc
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR corrects the configuration names in the Example files to match the filename of the configuration, sans the numeric prefix.

**This Pull Request (PR) fixes the following issues:**
- Fixes #15

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?
 
@johlju - would you mind reviewing when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/filecontentdsc/16)
<!-- Reviewable:end -->
