### PR TITLE
Fix error when KeyValuePair file is empty or does not exist - Fixes #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   - Removing uneccesary `#region` blocks.
   - Conversion of double quotes to single quotes where possible.
   - Replace variables with string litterals in `describe` block description.
+- KeyValuePairFile:
+  - Improve unit tests to simplify and cover additional test cases.
+  - Fix error occuring when file is empty or does not exist - fixes [Issue #34](https://github.com/PlagueHO/FileContentDsc/issues/34).
 
 ## 1.2.0.0
 

--- a/DSCResources/DSR_KeyValuePairFile/DSR_KeyValuePairFile.psm1
+++ b/DSCResources/DSR_KeyValuePairFile/DSR_KeyValuePairFile.psm1
@@ -41,7 +41,7 @@ function Get-TargetResource
 
     $ensure = 'Absent'
     $text = $null
-    $fileEncoding = 'ASCII'
+    $fileEncoding = $null
 
     if (Test-Path -Path $Path)
     {

--- a/DSCResources/DSR_KeyValuePairFile/en-US/DSR_KeyValuePairFile.strings.psd1
+++ b/DSCResources/DSR_KeyValuePairFile/en-US/DSR_KeyValuePairFile.strings.psd1
@@ -11,6 +11,8 @@ ConvertFrom-StringData @'
     KeyNotFoundAndShouldNotExistMessage = Key '{1}' not found in file '{0}' and should not exist. Change not required.
     KeyFoundButNoReplacementMessage = Key '{1}' found in file '{0}' and should exist and value(s) are correct. Change not required.
     KeyFoundButShouldNotExistMessage = Key '{1}' found in file '{0}' but should not exist. Change required.
+    KeyValuePairFileNotFound = Key Value Pair file '{0}' not found.
+    KeyValuePairFileIsEmpty = Key Value Pair file '{0}' is empty.
     FileParentNotFoundError = File parent path '{0}' not found.
     FileEncodingNotInDesiredState = File encoding is set to '{0}' but should be set to '{1}', Change required.
 '@

--- a/Tests/Unit/DSR_KeyValuePairFile.Tests.ps1
+++ b/Tests/Unit/DSR_KeyValuePairFile.Tests.ps1
@@ -107,24 +107,103 @@ $($script:testAddedName)=$($script:testText)
 "@
 
         Describe 'DSR_KeyValuePairFile\Get-TargetResource' -Tag 'Get' {
-            Context 'File exists and contains matching key' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            BeforeAll {
+                Mock -CommandName Assert-ParametersValid
+            }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
+            Context 'When the file does not exist' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $false }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    { $script:result = Get-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return expected values' {
+                    $script:result.Path   | Should -Be $script:testTextFile
+                    $script:result.Name   | Should -Be $script:testName
+                    $script:result.Ensure | Should -Be 'Absent'
+                    $script:result.Type   | Should -Be 'Text'
+                    $script:result.Text   | Should -BeNullOrEmpty
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Test-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When the file is empty' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    { $script:result = Get-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return expected values' {
+                    $script:result.Path   | Should -Be $script:testTextFile
+                    $script:result.Name   | Should -Be $script:testName
+                    $script:result.Ensure | Should -Be 'Absent'
+                    $script:result.Type   | Should -Be 'Text'
+                    $script:result.Text   | Should -BeNullOrEmpty
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Test-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When the file exists and contains a matching key' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
+
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 $script:result = $null
 
@@ -145,34 +224,32 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Test-Path `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and does not contain matching key' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and does not contain a matching key' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 $script:result = $null
 
@@ -193,44 +270,36 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
-
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Test-Path `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
         }
 
         Describe 'DSR_KeyValuePairFile\Set-TargetResource' -Tag 'Set' {
-            Context 'File does not exist' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            BeforeAll {
+                Mock -CommandName Assert-ParametersValid
+            }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $null } `
-                    -Verifiable
+            Context 'When the file does not exist' {
+                Mock -CommandName Get-Content
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Set-Content `
-                    -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq "$script:testName=$script:testText")
-                    } `
-                    -Verifiable
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -243,50 +312,33 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq "$script:testName=$script:testText")
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file is empty' {
+                Mock -CommandName Get-Content
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Set-Content `
-                    -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq $script:testFileExpectedTextContent)
-                    } `
-                    -Verifiable
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -299,50 +351,76 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
+                        -ParameterFilter {
+                            ($path -eq $script:testTextFile) -and `
+                            ($value -eq "$script:testName=$script:testText")
+                        } `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When the file exists and contains a matching key that should exist' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent } `
+                    -Verifiable
+
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding } `
+                    -Verifiable
+
+                Mock -CommandName Set-Content
+
+                It 'Should not throw an exception' {
+                    { Set-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName `
+                        -Ensure 'Present' `
+                        -Text $script:testText `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContent)
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and contain a secret' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and contain a secret' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Set-Content `
-                    -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq $script:testFileExpectedSecretContent)
-                    } `
-                    -Verifiable
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -356,45 +434,34 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedSecretContent)
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists does not contain matching key but key should exist' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists does not contain a matching key but key should exist' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Set-Content `
+                Mock -CommandName Set-Content `
                     -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentAdded)
@@ -412,50 +479,34 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContentAdded)
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains key with a different case that should exist and IgnoreNameCase is True' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a key with a different case that should exist and IgnoreNameCase is True' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Set-Content `
-                    -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq $script:testFileExpectedTextContentUpper)
-                    } `
-                    -Verifiable
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -469,46 +520,34 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContentUpper)
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and does not contain key with matching case and should not' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and does not contain a key with matching case and should not' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                # non-verifiable mocks
-                Mock `
-                    -CommandName Set-Content
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -521,46 +560,30 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
-                        -Exactly 0
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
+                        -Exactly -Times 0
                 }
             }
 
-            Context 'File exists and contains key with a different case but should not and IgnoreNameCase is True' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a key with a different case but should not and IgnoreNameCase is True' {
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Set-Content `
-                    -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq $script:testFileExpectedAbsentContent)
-                    } `
-                    -Verifiable
+                Mock -CommandName Set-Content
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -573,50 +596,38 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Set-Content `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedAbsentContent)
                         } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
         }
 
         Describe 'DSR_KeyValuePairFile\Test-TargetResource' -Tag 'Test' {
-            Context 'File exists and does not contain matching key but it should' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            BeforeAll {
+                Mock -CommandName Assert-ParametersValid
+            }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+            Context 'When the file does not exist but should contain a matching key' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $false }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -633,40 +644,165 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
-                        -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                    Assert-MockCalled -CommandName Get-Content `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Exactly -Times 0
                 }
             }
 
-            Context 'File exists and does not contain matching key and should not' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file does not exist and should not contain a matching key' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $false }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                It 'Should not throw an exception' {
+                    { $script:result = Test-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName.ToUpper() `
+                        -Ensure 'Absent' `
+                        -Text $script:testText `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
 
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                It 'Should return true' {
+                    $script:result | Should -Be $true
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When the file exists but is empty so does not contain a matching key but it should' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
+
+                It 'Should not throw an exception' {
+                    { $script:result = Test-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName.ToUpper() `
+                        -Ensure 'Present' `
+                        -Text $script:testText `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return false' {
+                    $script:result | Should -Be $false
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When the file exists but is empty so does not contain a matching and should not' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content
+                Mock -CommandName Get-FileEncoding
+
+                It 'Should not throw an exception' {
+                    { $script:result = Test-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName.ToUpper() `
+                        -Ensure 'Absent' `
+                        -Text $script:testText `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return true' {
+                    $script:result | Should -Be $true
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When the file exists and does not contain a matching key but it should' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
+
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
+
+                It 'Should not throw an exception' {
+                    { $script:result = Test-TargetResource `
+                        -Path $script:testTextFile `
+                        -Name $script:testName.ToUpper() `
+                        -Ensure 'Present' `
+                        -Text $script:testText `
+                        -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return false' {
+                    $script:result | Should -Be $false
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-Content `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When the file exists and does not contain a matching key and should not' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
+
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -683,40 +819,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and does not contain matching key and should not but encoding is not in desired state' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and does not contain a matching key and should not but encoding is not in desired state' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testNonCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testNonCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -733,40 +857,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -783,40 +895,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match but encoding is not in desired state' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match but encoding is not in desired state' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testNonCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testNonCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -834,40 +934,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values do not match secret text' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values do not match secret text' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -885,40 +973,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match secret text' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match secret text' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedSecretContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedSecretContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -936,40 +1012,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match secret text but encoding is not in desired state' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match secret text but encoding is not in desired state' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedSecretContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedSecretContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testNonCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testNonCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -988,40 +1052,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains key with different case that should exist and values match and IgnoreNameCase is True' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a key with different case that should exist and values match and IgnoreNameCase is True' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -1039,40 +1091,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match but are different case and IgnoreValueCase is False' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match but are different case and IgnoreValueCase is False' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -1089,40 +1129,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should exist and values match but are different case and IgnoreValueCase is True' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should exist and values match but are different case and IgnoreValueCase is True' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -1140,40 +1168,28 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File exists and contains matching key that should not exist' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Assert-ParametersValid `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -Verifiable
+            Context 'When the file exists and contains a matching key that should not exist' {
+                Mock -CommandName Test-Path `
+                    -MockWith { $true }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ModuleName 'DSR_KeyValuePairFile' `
-                    -MockWith { $true } `
-                    -Verifiable
+                Mock -CommandName Get-Content `
+                    -MockWith { $script:testFileExpectedTextContent }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testFileExpectedTextContent } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Get-FileEncoding `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                Mock -CommandName Get-FileEncoding `
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
@@ -1190,31 +1206,27 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Assert-ParametersValid -Exactly 1
+                    Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Exactly -Times 1
 
-                    Assert-MockCalled `
-                        -CommandName Get-Content `
+                    Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
-                        -Exactly 1
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Get-FileEncoding `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
         }
 
         Describe 'DSR_KeyValuePairFile\Assert-ParametersValid' {
-            Context 'File parent path exists' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Split-Path `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testTextFile } `
-                    -Verifiable
+            BeforeAll {
+                Mock -CommandName Split-Path -MockWith { $script:testTextFile }
+            }
 
-                Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $true } `
-                    -Verifiable
+            Context 'When the file parent path exists' {
+                Mock -CommandName Test-Path -MockWith { $true }
 
                 It 'Should not throw an exception' {
                     { Assert-ParametersValid `
@@ -1225,24 +1237,18 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Test-Path -Exactly 1
+                    Assert-MockCalled -CommandName Split-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Test-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
 
-            Context 'File parent path does not exist' {
-                # verifiable (should be called) mocks
-                Mock `
-                    -CommandName Split-Path `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $script:testTextFile } `
-                    -Verifiable
-
-                Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter { $path -eq $script:testTextFile } `
-                    -MockWith { $false } `
-                    -Verifiable
+            Context 'When the file parent path does not exist' {
+                Mock -CommandName Test-Path -MockWith { $false }
 
                 $errorRecord = Get-InvalidArgumentRecord `
                     -Message ($script:localizedData.FileParentNotFoundError -f $script:testTextFile) `
@@ -1257,8 +1263,13 @@ $($script:testAddedName)=$($script:testText)
                 }
 
                 It 'Should call the expected mocks' {
-                    Assert-VerifiableMock
-                    Assert-MockCalled -CommandName Test-Path -Exactly 1
+                    Assert-MockCalled -CommandName Split-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled -CommandName Test-Path `
+                        -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Exactly -Times 1
                 }
             }
         }

--- a/Tests/Unit/DSR_KeyValuePairFile.Tests.ps1
+++ b/Tests/Unit/DSR_KeyValuePairFile.Tests.ps1
@@ -138,16 +138,20 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Test-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -Exactly -Times 0
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -179,18 +183,22 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Test-Path `
                         -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
                         -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
                         -ParameterFilter { $path -eq $script:testTextFile } `
+                        -Scope Context `
                         -Exactly -Times 1
                 }
             }
@@ -225,17 +233,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Test-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -271,17 +283,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Test-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -313,17 +329,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq "$script:testName=$script:testText")
@@ -352,17 +372,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq "$script:testName=$script:testText")
@@ -373,12 +397,10 @@ $($script:testAddedName)=$($script:testText)
 
             Context 'When the file exists and contains a matching key that should exist' {
                 Mock -CommandName Get-Content `
-                    -MockWith { $script:testFileContent } `
-                    -Verifiable
+                    -MockWith { $script:testFileContent }
 
                 Mock -CommandName Get-FileEncoding `
-                    -MockWith { $script:testCompliantEncoding.Encoding } `
-                    -Verifiable
+                    -MockWith { $script:testCompliantEncoding.Encoding }
 
                 Mock -CommandName Set-Content
 
@@ -394,17 +416,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContent)
@@ -435,17 +461,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedSecretContent)
@@ -465,8 +495,7 @@ $($script:testAddedName)=$($script:testText)
                     -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentAdded)
-                    } `
-                    -Verifiable
+                    }
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -480,17 +509,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContentAdded)
@@ -521,17 +554,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedTextContentUpper)
@@ -561,17 +598,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -597,17 +638,21 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Set-Content `
+                        -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
                             ($value -eq $script:testFileExpectedAbsentContent)
@@ -645,12 +690,15 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -Exactly -Times 0
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -678,12 +726,15 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -Exactly -Times 0
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -711,13 +762,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -745,13 +799,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -Exactly -Times 0
                 }
             }
@@ -782,13 +839,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -820,13 +880,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -858,13 +921,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -896,13 +962,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -935,13 +1004,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -974,13 +1046,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1013,13 +1088,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1053,13 +1131,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1092,13 +1173,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1130,13 +1214,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1169,13 +1256,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1207,13 +1297,16 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Assert-ParametersValid `
+                        -Scope Context `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-Content `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1238,10 +1331,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Split-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Test-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }
@@ -1264,10 +1359,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Split-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
                     Assert-MockCalled -CommandName Test-Path `
+                        -Scope Context `
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
                 }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an error that occurs when the KeyValuePair file is empty or does not exist.

It also cleans up the unit tests to make them less fragile.

#### This Pull Request (PR) fixes the following issues

- Fixes #34

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this when you have a moment? Sorry about the length of the change in the unit tests - I decided to refactor them to make them less brittle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/filecontentdsc/35)
<!-- Reviewable:end -->
